### PR TITLE
Fix preview URL conversion to replace underscores with hyphens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - if: github.ref_name != github.event.repository.default_branch
         id: set_preview_env
         shell: bash
-        run: echo url="https://$(echo "${HEAD_REF:0:28}" | sed 's/[^_0-9a-z]/-/gi;s/-*$//').jwk.pages.dev/" >> "${GITHUB_OUTPUT}"
+        run: echo url="https://$(echo "${HEAD_REF:0:28}" | sed 's/[^0-9a-z]/-/gi;s/-*$//').jwk.pages.dev/" >> "${GITHUB_OUTPUT}"
         env:
           HEAD_REF: ${{ github.head_ref }}
       - name: Run tests on ${{ env.BASE_URL }}


### PR DESCRIPTION
Cloudflare Pages sanitizes branch aliases by replacing all
non-alphanumeric characters (including underscores) with hyphens.
The previous sed character class [^_0-9a-z] preserved underscores,
producing URLs like dependabot-npm_and_yarn-npm_.jwk.pages.dev instead
of dependabot-npm-and-yarn-npm.jwk.pages.dev.